### PR TITLE
Hint to disable autocorrect

### DIFF
--- a/resources/js/hebrewparsetrainer.js
+++ b/resources/js/hebrewparsetrainer.js
@@ -119,7 +119,7 @@ $(document).ready(function(){
 						<div class='col-md-8'>\
 							<div class='form-group'>\
 								<label for='trainer-input-"+input_count+"'>Parse:</label>\
-								<input type='text' class='form-control' id='trainer-input-"+input_count+"' placeholder='Q pf 3ms' spellcheck='false'/>\
+								<input type='text' class='form-control' id='trainer-input-"+input_count+"' placeholder='Q pf 3ms' spellcheck='false' autocorrect='off'/>\
 							</div>\
 						</div>\
 						<div class='col-md-4'>\


### PR DESCRIPTION
Proposed fix to #15. 

The [autocorrect](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#autocorrect) attribute works to hint to Safari (and, presumably, any other web browser that would want to view this attribute) that, for this input box, disable autocorrect.